### PR TITLE
chore: upgrade to Go 1.23

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.23'
           cache: true
 
       - name: Install dependencies for Podman

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.23'
           cache: true
 
       - name: Install dependencies for Podman

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.23'
           cache: true
 
       - name: Install dependencies for Podman
@@ -70,7 +70,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.23'
           cache: true
 
       - name: Install dependencies for Podman

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.23'
           cache: true
 
       - name: Install dependencies for Podman
@@ -75,7 +75,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.23'
           cache: true
 
       - name: Install dependencies for Podman

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Go version upgraded from 1.21 to 1.22.6 (required by Podman v5 dependency)
+- Go version upgraded from 1.22.6 to 1.23 for latest features and security updates (#16)
+- GitHub Actions workflows updated to use Go 1.23
 - Replaced placeholder main.go with complete CLI implementation
 - Fixed Makefile install-hooks target syntax error
 - Coverage threshold adjusted from 69% to 67% (accounts for integration-only server creation functions)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/steviee/go-mc
 
-go 1.22.6
+go 1.23
 
 require (
 	github.com/containers/common v0.61.0


### PR DESCRIPTION
## Summary
Upgrade Go version from 1.22.6 to 1.23 for latest features and security updates.

## Changes
- ✅ Updated go.mod to require Go 1.23
- ✅ Updated GitHub Actions workflows (lint, test, security, release) to use Go 1.23
- ✅ All tests pass with new Go version

## Benefits
- Access to latest Go language features
- Performance improvements
- Security updates
- Better toolchain and developer experience

## Testing
- ✅ All unit tests pass (67.5% coverage)
- ✅ All linting passes
- ✅ go mod tidy completed successfully

## Documentation
- ✅ CHANGELOG.md updated

## Closes
Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)