### PR TITLE
fix(system): replace policykit-1 with polkitd for Debian 13 compatibility

### DIFF
--- a/internal/cli/system/setup.go
+++ b/internal/cli/system/setup.go
@@ -321,7 +321,7 @@ func isAlreadyInitialized() (bool, error) {
 func checkDependencies() ([]Dependency, error) {
 	deps := []Dependency{
 		{Name: "Podman", Command: "podman", Package: "podman", Required: true, Installed: false},
-		{Name: "PolicyKit", Command: "pkaction", Package: "policykit-1", Required: true, Installed: false},
+		{Name: "PolicyKit", Command: "pkaction", Package: "polkitd", Required: true, Installed: false},
 		{Name: "curl", Command: "curl", Package: "curl", Required: false, Installed: false},
 		{Name: "git", Command: "git", Package: "git", Required: false, Installed: false},
 	}

--- a/internal/cli/system/setup_test.go
+++ b/internal/cli/system/setup_test.go
@@ -106,7 +106,7 @@ func TestCheckDependencies(t *testing.T) {
 			foundPolicyKit = true
 			assert.True(t, dep.Required, "PolicyKit should be required")
 			assert.Equal(t, "PolicyKit", dep.Name)
-			assert.Equal(t, "policykit-1", dep.Package)
+			assert.Equal(t, "polkitd", dep.Package)
 		}
 	}
 	assert.True(t, foundPodman, "Podman should be in dependency list")

--- a/internal/container/client.go
+++ b/internal/container/client.go
@@ -294,7 +294,7 @@ RECOMMENDED: Run the automated setup:
 This will install and configure Podman, polkitd, and all required dependencies.
 
 MANUAL INSTALLATION (if needed):
-  Debian/Ubuntu: sudo apt install podman policykit-1
+  Debian/Ubuntu: sudo apt install podman polkitd
   For other systems: https://podman.io/getting-started/installation
 
 After manual installation, enable and start the Podman socket:

--- a/internal/container/client_test.go
+++ b/internal/container/client_test.go
@@ -75,7 +75,7 @@ func TestGetNoRuntimeMessage(t *testing.T) {
 	assert.Contains(t, msg, "No container runtime available")
 	assert.Contains(t, msg, "go-mc system setup")
 	assert.Contains(t, msg, "podman")
-	assert.Contains(t, msg, "policykit-1")
+	assert.Contains(t, msg, "polkitd")
 	assert.Contains(t, msg, "systemctl")
 }
 


### PR DESCRIPTION
## Summary
- Replaced package name `policykit-1` with `polkitd` for Debian 13 (Trixie) compatibility
- Updated all references in code, tests, and documentation

## Motivation
When running `go-mc system setup` on Debian 13 (Trixie), the installation failed with:

```
E: Für Paket »policykit-1« existiert kein Installationskandidat.
Doch die folgenden Pakete ersetzen es:
  polkitd pkexec
```

### Root Cause
In Debian Trixie, the `policykit-1` package was renamed to `polkitd`. The old package name no longer exists in the repositories.

## Changes
- **`internal/cli/system/setup.go`** - Updated dependency package from `policykit-1` to `polkitd`
- **`internal/cli/system/setup_test.go`** - Updated test expectations
- **`internal/container/client.go`** - Updated manual installation command in error messages
- **`internal/container/client_test.go`** - Updated test expectations

The `pkaction` command remains unchanged (it's still provided by the `polkitd` package).

## Compatibility
✅ **Debian 12 (Bookworm)** - `polkitd` package available
✅ **Debian 13 (Trixie)** - `polkitd` package is the standard name
⚠️ **Older Debian** - Not officially supported (go-mc requires Debian 12+)

## Testing
- [x] All system setup tests pass (`TestCheckDependencies`)
- [x] Container client tests pass (`TestGetNoRuntimeMessage`)
- [x] Local test run successful

```bash
$ go test ./internal/cli/system/... -v
PASS
ok  	github.com/steviee/go-mc/internal/cli/system	0.315s

$ go test ./internal/container/... -v -run TestGetNoRuntimeMessage
PASS
ok  	github.com/steviee/go-mc/internal/container	0.009s
```

## Before Fix
```
Missing dependencies:
  ✗ Podman
  ✗ PolicyKit

Installing packages...
E: Für Paket »policykit-1« existiert kein Installationskandidat.
Error: failed to install dependencies: package installation failed: exit status 100
```

## After Fix
```
Missing dependencies:
  ✗ Podman
  ✗ PolicyKit

Installing packages...
✓ Dependencies installed
```

## Checklist
- [x] Code follows project guidelines
- [x] All tests pass
- [x] Documentation updated
- [x] Backward compatible with Debian 12

🤖 Generated with [Claude Code](https://claude.com/claude-code)