### PR TITLE
fix(test): resolve failing unit tests in lifecycle and container packages

### DIFF
--- a/internal/cli/servers/lifecycle.go
+++ b/internal/cli/servers/lifecycle.go
@@ -96,7 +96,15 @@ func outputOperationResult(stdout io.Writer, operation string, result *Operation
 	jsonMode := isJSONMode()
 
 	if jsonMode {
-		return outputOperationJSON(stdout, operation, result)
+		// Output JSON first
+		if err := outputOperationJSON(stdout, operation, result); err != nil {
+			return err
+		}
+		// Then return error if any operations failed (consistent with human output)
+		if result.HasFailures() {
+			return fmt.Errorf("%d server(s) failed", len(result.Failed))
+		}
+		return nil
 	}
 
 	return outputOperationHuman(stdout, operation, result)

--- a/internal/cli/servers/lifecycle_unit_test.go
+++ b/internal/cli/servers/lifecycle_unit_test.go
@@ -66,7 +66,7 @@ func TestOutputOperationResult(t *testing.T) {
 				Skipped: []string{},
 			},
 			jsonMode: true,
-			wantErr:  false,
+			wantErr:  true, // Changed: Should return error like human mode for consistency
 			contains: []string{"error"},
 		},
 	}

--- a/internal/container/client_test.go
+++ b/internal/container/client_test.go
@@ -158,12 +158,20 @@ func TestNewClient_InvalidRuntime(t *testing.T) {
 
 func TestNewClient_NilConfig(t *testing.T) {
 	// This test verifies that NewClient uses default config when nil is passed
-	// We expect it to try auto-detection and fail (since we don't have a real daemon)
+	// and doesn't panic. It may succeed (if a daemon is running) or fail (if not).
 	ctx := context.Background()
 
-	_, err := NewClient(ctx, nil)
-	// Should fail because no daemon is running, but should not panic
-	assert.Error(t, err)
+	client, err := NewClient(ctx, nil)
+	// Either succeeds (daemon running) or fails (no daemon) - both are valid
+	// The important part is that it doesn't panic with nil config
+	if err == nil {
+		// Success case - daemon is running
+		assert.NotNil(t, client)
+		_ = client.Close()
+	} else {
+		// Failure case - no daemon running (expected in CI without daemon)
+		assert.Error(t, err)
+	}
 }
 
 func TestNewClient_ExplicitSocket_NotFound(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixed four unit tests that were failing on main, blocking CI builds.

## Problem

The following tests were failing:
1. `TestRunRestart_JSONOutput` - Expected error return from runRestart in JSON mode
2. `TestRunStart_JSONOutput` - Expected error return from runStart in JSON mode  
3. `TestRunStop_JSONOutput` - Expected error return from runStop in JSON mode
4. `TestNewClient_NilConfig` - Assumed no container daemon is running

## Solution

### Lifecycle Tests (1-3)

**Root Cause**: `outputOperationResult` in JSON mode was not returning an error when operations failed, but the integration tests expected errors.

**Fix**:
- Modified `outputOperationResult` to check for failures after outputting JSON and return an error if any operations failed
- This makes JSON mode behavior consistent with human mode (both return errors on failure)
- Updated `TestOutputOperationResult/failures_in_JSON_mode` test expectation to `wantErr: true` for consistency

### Container Test (4)

**Root Cause**: Test assumed no container daemon would be running, but Podman/Docker may be running in dev/CI environments.

**Fix**:
- Changed test to accept both success (daemon running) and failure (no daemon) outcomes
- Test now verifies that nil config doesn't cause a panic, regardless of daemon availability

## Changes

**Files Modified:**
- `internal/cli/servers/lifecycle.go` - Added error return logic to `outputOperationResult` for JSON mode
- `internal/cli/servers/lifecycle_unit_test.go` - Fixed test expectation for consistency
- `internal/container/client_test.go` - Made test robust to daemon availability

## Testing

- [x] All unit tests pass locally
- [x] Behavior is consistent between JSON and human output modes
- [x] No new lint errors introduced (existing backup lint errors from PR #70)
- [x] Tests are robust to environment differences (daemon availability)

## Benefits

- ✅ CI builds no longer blocked by failing tests
- ✅ Consistent error handling between JSON and human modes
- ✅ More robust tests that work in any environment

Fixes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)